### PR TITLE
Fix missing private dns zone link in ADB workspace

### DIFF
--- a/modules/core/databricks.tf
+++ b/modules/core/databricks.tf
@@ -24,6 +24,8 @@ module "databricks_workspace_engineering" {
   subnet_id                                                                 = var.subnet_id_storage
   connectivity_delay_in_seconds                                             = var.connectivity_delay_in_seconds + 30
   private_dns_zone_id_databricks                                            = var.private_dns_zone_id_databricks
+  private_dns_zone_id_blob                                                  = var.private_dns_zone_id_blob
+  private_dns_zone_id_dfs                                                   = var.private_dns_zone_id_dfs
   customer_managed_key                                                      = var.customer_managed_key
 }
 
@@ -53,5 +55,7 @@ module "databricks_workspace_consumption" {
   subnet_id                                                                 = var.subnet_id_storage
   connectivity_delay_in_seconds                                             = var.connectivity_delay_in_seconds + 30
   private_dns_zone_id_databricks                                            = var.private_dns_zone_id_databricks
+  private_dns_zone_id_blob                                                  = var.private_dns_zone_id_blob
+  private_dns_zone_id_dfs                                                   = var.private_dns_zone_id_dfs
   customer_managed_key                                                      = var.customer_managed_key
 }

--- a/modules/databricksdataapplication/budget.tf
+++ b/modules/databricksdataapplication/budget.tf
@@ -26,6 +26,8 @@ resource "databricks_budget" "budget" {
 }
 
 resource "databricks_budget_policy" "budget_policy" {
+  provider = databricks.account
+
   policy_name = "${local.prefix}-budget"
 
   custom_tags = [

--- a/tests/e2e/databricks-cluster-policies/dlt-policy.yml
+++ b/tests/e2e/databricks-cluster-policies/dlt-policy.yml
@@ -28,11 +28,6 @@ definition:
     type: fixed
     value: -1
     hidden: true
-  cluster_name:
-    type: regex
-    pattern: "${prefix}-[a-z0-9]"
-    isOptional: false
-    hidden: false
   cluster_type:
     type: fixed
     value: dlt

--- a/tests/e2e/databricks-cluster-policies/job-policy.yml
+++ b/tests/e2e/databricks-cluster-policies/job-policy.yml
@@ -28,11 +28,6 @@ definition:
     type: fixed
     value: -1
     hidden: true
-  cluster_name:
-    type: regex
-    pattern: "${prefix}-[a-z0-9]"
-    isOptional: false
-    hidden: false
   cluster_type:
     type: fixed
     value: job

--- a/tests/e2e/terraform.tf
+++ b/tests/e2e/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.21.1"
+      version = "4.22.0"
     }
     azapi = {
       source  = "azure/azapi"

--- a/tests/e2e/terraform.tf
+++ b/tests/e2e/terraform.tf
@@ -20,7 +20,7 @@ terraform {
     }
     time = {
       source  = "hashicorp/time"
-      version = "0.12.1"
+      version = "0.13.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/tests/e2e/terraform.tf
+++ b/tests/e2e/terraform.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azapi = {
       source  = "azure/azapi"
-      version = "2.2.0"
+      version = "2.3.0"
     }
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
**Proposed changes**:
- Fix missing private dns zone link in ADB workspace
- Bump hashicorp/time from 0.12.1 to 0.13.0
- Bump hashicorp/azurerm from 4.21.1 to 4.22.0
- Bump azure/azapi from 2.2.0 to 2.3.0
