### PR TITLE
Add support for Databricks network policy & enable cmk

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -34,7 +34,7 @@ jobs:
       tenant_id: "37963dd4-f4e6-40f8-a7d6-24b97919e452"
       subscription_id: "9842be63-c8c0-4647-a5d1-0c5e7f8bbb25"
     secrets:
-      CLIENT_ID_PLAN: ${{ secrets.CLIENT_ID_PLAN }}
+      CLIENT_ID_PLAN: ${{ secrets.CLIENT_ID }}
       CLIENT_ID_APPLY: ${{ secrets.CLIENT_ID }}
 
   terraform_destroy:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -34,7 +34,7 @@ jobs:
       tenant_id: "37963dd4-f4e6-40f8-a7d6-24b97919e452"
       subscription_id: "9842be63-c8c0-4647-a5d1-0c5e7f8bbb25"
     secrets:
-      CLIENT_ID_PLAN: ${{ secrets.CLIENT_ID }}
+      CLIENT_ID_PLAN: ${{ secrets.CLIENT_ID_PLAN }}
       CLIENT_ID_APPLY: ${{ secrets.CLIENT_ID }}
 
   terraform_destroy:

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
-- <a name="requirement_databricks"></a> [databricks](#requirement\_databricks) (~> 1.73)
+- <a name="requirement_databricks"></a> [databricks](#requirement\_databricks) (~> 1.81)
 
 - <a name="requirement_fabric"></a> [fabric](#requirement\_fabric) (~> 1.0)
 
@@ -323,6 +323,27 @@ Description: Specifies which enhanced compliance security profiles ('HIPAA', 'PC
 Type: `list(string)`
 
 Default: `[]`
+
+### <a name="input_databricks_network_policy_details"></a> [databricks\_network\_policy\_details](#input\_databricks\_network\_policy\_details)
+
+Description: Specifies the name of the ncc connectivity config name that should be attached to the databricks workspace.
+
+Type:
+
+```hcl
+object({
+    allowed_internet_destinations = optional(list(object({
+      destination               = string
+      internet_destination_type = optional(string, "DNS_NAME")
+    })), [])
+    allowed_storage_destinations = optional(list(object({
+      azure_storage_account    = string
+      storage_destination_type = string
+    })), [])
+  })
+```
+
+Default: `{}`
 
 ### <a name="input_databricks_workspace_binding_catalog"></a> [databricks\_workspace\_binding\_catalog](#input\_databricks\_workspace\_binding\_catalog)
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Type:
 ```hcl
 object({
     key_vault_id                     = string,
+    key_vault_key_id                 = string,
     key_vault_key_versionless_id     = string,
     user_assigned_identity_id        = string,
     user_assigned_identity_client_id = string,

--- a/databricks.tf
+++ b/databricks.tf
@@ -16,6 +16,7 @@ module "databricks_core" {
   # Service variables
   storage_account_ids                              = module.core.storage_account_ids
   storage_dependencies                             = module.core.storage_dependencies
+  databricks_account_id                            = var.databricks_account_id
   databricks_workspace_details                     = local.databricks_workspace_details
   databricks_private_endpoint_rules                = local.databricks_private_endpoint_rules
   databricks_ip_access_list_allow                  = []

--- a/modules/core/variables.tf
+++ b/modules/core/variables.tf
@@ -221,6 +221,7 @@ variable "customer_managed_key" {
   description = "Specifies the customer managed key configurations."
   type = object({
     key_vault_id                     = string,
+    key_vault_key_id                 = string,
     key_vault_key_versionless_id     = string,
     user_assigned_identity_id        = string,
     user_assigned_identity_client_id = string,
@@ -231,6 +232,7 @@ variable "customer_managed_key" {
   validation {
     condition = alltrue([
       var.customer_managed_key == null || length(split("/", try(var.customer_managed_key.key_vault_id, ""))) == 9,
+      var.customer_managed_key == null || startswith(try(var.customer_managed_key.key_vault_key_id, ""), "https://"),
       var.customer_managed_key == null || startswith(try(var.customer_managed_key.key_vault_key_versionless_id, ""), "https://"),
       var.customer_managed_key == null || length(split("/", try(var.customer_managed_key.user_assigned_identity_id, ""))) == 9,
       var.customer_managed_key == null || length(try(var.customer_managed_key.user_assigned_identity_client_id, "")) >= 2,

--- a/modules/dataapplication/variables.tf
+++ b/modules/dataapplication/variables.tf
@@ -448,6 +448,7 @@ variable "customer_managed_key" {
   description = "Specifies the customer managed key configurations."
   type = object({
     key_vault_id                     = string,
+    key_vault_key_id                 = string,
     key_vault_key_versionless_id     = string,
     user_assigned_identity_id        = string,
     user_assigned_identity_client_id = string,
@@ -458,6 +459,7 @@ variable "customer_managed_key" {
   validation {
     condition = alltrue([
       var.customer_managed_key == null || length(split("/", try(var.customer_managed_key.key_vault_id, ""))) == 9,
+      var.customer_managed_key == null || startswith(try(var.customer_managed_key.key_vault_key_id, ""), "https://"),
       var.customer_managed_key == null || startswith(try(var.customer_managed_key.key_vault_key_versionless_id, ""), "https://"),
       var.customer_managed_key == null || length(split("/", try(var.customer_managed_key.user_assigned_identity_id, ""))) == 9,
       var.customer_managed_key == null || length(try(var.customer_managed_key.user_assigned_identity_client_id, "")) >= 2,

--- a/modules/databrickscore/disablelegacy.tf
+++ b/modules/databrickscore/disablelegacy.tf
@@ -9,3 +9,9 @@ resource "databricks_disable_legacy_access_setting" "disable_legacy_access_setti
 #     value = true
 #   }
 # }
+
+# resource "databricks_disable_legacy_features_setting" "disable_legacy_features_setting_engineering" { # Currently in private preview
+#   disable_legacy_features {
+#     value = true
+#   }
+# }

--- a/modules/databrickscore/networkoption.tf
+++ b/modules/databrickscore/networkoption.tf
@@ -1,8 +1,8 @@
-resource "databricks_workspace_network_option" "workspace_network_option" {
-  provider = databricks.account
+# resource "databricks_workspace_network_option" "workspace_network_option" {
+#   provider = databricks.account
 
-  for_each = var.databricks_workspace_details
+#   for_each = var.databricks_workspace_details
 
-  network_policy_id = databricks_account_network_policy.account_network_policy.network_policy_id
-  workspace_id      = each.value.workspace_id
-}
+#   network_policy_id = databricks_account_network_policy.account_network_policy.network_policy_id
+#   workspace_id      = each.value.workspace_id
+# }

--- a/modules/databrickscore/networkoption.tf
+++ b/modules/databrickscore/networkoption.tf
@@ -3,6 +3,6 @@ resource "databricks_workspace_network_option" "workspace_network_option" {
 
   for_each = var.databricks_workspace_details
 
-  network_policy_id = databricks_account_network_policy.account_network_policy.id
+  network_policy_id = databricks_account_network_policy.account_network_policy.network_policy_id
   workspace_id      = each.value.workspace_id
 }

--- a/modules/databrickscore/networkoption.tf
+++ b/modules/databrickscore/networkoption.tf
@@ -1,0 +1,8 @@
+resource "databricks_workspace_network_option" "workspace_network_option" {
+  provider = databricks.account
+
+  for_each = var.databricks_workspace_details
+
+  network_policy_id = databricks_account_network_policy.account_network_policy.id
+  workspace_id      = each.value.workspace_id
+}

--- a/modules/databrickscore/networkpolicy.tf
+++ b/modules/databrickscore/networkpolicy.tf
@@ -1,0 +1,15 @@
+resource "databricks_account_network_policy" "account_network_policy" {
+  provider = databricks.account
+
+  account_id        = var.databricks_account_id
+  network_policy_id = "${local.prefix}-default"
+  egress {
+    restriction_mode              = "RESTRICTED_ACCESS"
+    allowed_internet_destinations = var.databricks_network_policy_details.allowed_internet_destinations
+    allowed_storage_destinations  = var.databricks_network_policy_details.allowed_storage_destinations
+    policy_enforcement {
+      dry_run_mode_product_filter = []
+      enforcement_mode            = "ENFORCED"
+    }
+  }
+}

--- a/modules/databrickscore/networkpolicy.tf
+++ b/modules/databrickscore/networkpolicy.tf
@@ -1,17 +1,17 @@
-resource "databricks_account_network_policy" "account_network_policy" {
-  provider = databricks.account
+# resource "databricks_account_network_policy" "account_network_policy" {
+#   provider = databricks.account
 
-  account_id        = var.databricks_account_id
-  network_policy_id = "${local.prefix}-default"
-  egress = {
-    network_access = {
-      restriction_mode              = "RESTRICTED_ACCESS"
-      allowed_internet_destinations = var.databricks_network_policy_details.allowed_internet_destinations
-      allowed_storage_destinations  = var.databricks_network_policy_details.allowed_storage_destinations
-      policy_enforcement = {
-        dry_run_mode_product_filter = []
-        enforcement_mode            = "ENFORCED"
-      }
-    }
-  }
-}
+#   account_id        = var.databricks_account_id
+#   network_policy_id = "${local.prefix}-default"
+#   egress = {
+#     network_access = {
+#       restriction_mode              = "RESTRICTED_ACCESS"
+#       allowed_internet_destinations = var.databricks_network_policy_details.allowed_internet_destinations
+#       allowed_storage_destinations  = var.databricks_network_policy_details.allowed_storage_destinations
+#       policy_enforcement = {
+#         dry_run_mode_product_filter = []
+#         enforcement_mode            = "ENFORCED"
+#       }
+#     }
+#   }
+# }

--- a/modules/databrickscore/networkpolicy.tf
+++ b/modules/databrickscore/networkpolicy.tf
@@ -3,11 +3,11 @@ resource "databricks_account_network_policy" "account_network_policy" {
 
   account_id        = var.databricks_account_id
   network_policy_id = "${local.prefix}-default"
-  egress {
+  egress = {
     restriction_mode              = "RESTRICTED_ACCESS"
     allowed_internet_destinations = var.databricks_network_policy_details.allowed_internet_destinations
     allowed_storage_destinations  = var.databricks_network_policy_details.allowed_storage_destinations
-    policy_enforcement {
+    policy_enforcement = {
       dry_run_mode_product_filter = []
       enforcement_mode            = "ENFORCED"
     }

--- a/modules/databrickscore/networkpolicy.tf
+++ b/modules/databrickscore/networkpolicy.tf
@@ -4,12 +4,14 @@ resource "databricks_account_network_policy" "account_network_policy" {
   account_id        = var.databricks_account_id
   network_policy_id = "${local.prefix}-default"
   egress = {
-    restriction_mode              = "RESTRICTED_ACCESS"
-    allowed_internet_destinations = var.databricks_network_policy_details.allowed_internet_destinations
-    allowed_storage_destinations  = var.databricks_network_policy_details.allowed_storage_destinations
-    policy_enforcement = {
-      dry_run_mode_product_filter = []
-      enforcement_mode            = "ENFORCED"
+    network_access = {
+      restriction_mode              = "RESTRICTED_ACCESS"
+      allowed_internet_destinations = var.databricks_network_policy_details.allowed_internet_destinations
+      allowed_storage_destinations  = var.databricks_network_policy_details.allowed_storage_destinations
+      policy_enforcement = {
+        dry_run_mode_product_filter = []
+        enforcement_mode            = "ENFORCED"
+      }
     }
   }
 }

--- a/modules/databrickscore/restrictworkspaceadminssetting.tf
+++ b/modules/databrickscore/restrictworkspaceadminssetting.tf
@@ -1,0 +1,5 @@
+resource "databricks_restrict_workspace_admins_setting" "restrict_workspace_admins_setting_engineering" {
+  restrict_workspace_admins {
+    status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
+  }
+}

--- a/modules/databrickscore/terraform.tf
+++ b/modules/databrickscore/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = "~> 1.73"
+      version = "~> 1.81"
       configuration_aliases = [
         databricks.account
       ]

--- a/terraform.tf
+++ b/terraform.tf
@@ -20,7 +20,7 @@ terraform {
     }
     databricks = {
       source  = "databricks/databricks"
-      version = "~> 1.73"
+      version = "~> 1.81"
     }
     time = {
       source  = "hashicorp/time"

--- a/tests/e2e/main.tf
+++ b/tests/e2e/main.tf
@@ -25,7 +25,7 @@ module "data_landing_zone" {
   databricks_cluster_policy_file_variables         = var.databricks_cluster_policy_file_variables
   databricks_account_id                            = var.databricks_account_id
   databricks_network_connectivity_config_name      = var.databricks_network_connectivity_config_name
-  databricks_network_policy_details = var.databricks_network_policy_details
+  databricks_network_policy_details                = var.databricks_network_policy_details
   databricks_compliance_security_profile_standards = var.databricks_compliance_security_profile_standards
   databricks_workspace_binding_catalog             = var.databricks_workspace_binding_catalog
   fabric_capacity_details                          = var.fabric_capacity_details

--- a/tests/e2e/main.tf
+++ b/tests/e2e/main.tf
@@ -25,6 +25,7 @@ module "data_landing_zone" {
   databricks_cluster_policy_file_variables         = var.databricks_cluster_policy_file_variables
   databricks_account_id                            = var.databricks_account_id
   databricks_network_connectivity_config_name      = var.databricks_network_connectivity_config_name
+  databricks_network_policy_details = var.databricks_network_policy_details
   databricks_compliance_security_profile_standards = var.databricks_compliance_security_profile_standards
   databricks_workspace_binding_catalog             = var.databricks_workspace_binding_catalog
   fabric_capacity_details                          = var.fabric_capacity_details

--- a/tests/e2e/terraform.tf
+++ b/tests/e2e/terraform.tf
@@ -12,7 +12,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "3.3.0"
+      version = "3.4.0"
     }
     fabric = {
       source  = "microsoft/fabric"

--- a/tests/e2e/terraform.tf
+++ b/tests/e2e/terraform.tf
@@ -20,7 +20,7 @@ terraform {
     }
     databricks = {
       source  = "databricks/databricks"
-      version = "1.80.0"
+      version = "1.81.1"
     }
     time = {
       source  = "hashicorp/time"

--- a/tests/e2e/terraform.tf
+++ b/tests/e2e/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.29.0"
+      version = "4.30.0"
     }
     azapi = {
       source  = "azure/azapi"

--- a/tests/e2e/variables.tf
+++ b/tests/e2e/variables.tf
@@ -342,6 +342,7 @@ variable "customer_managed_key" {
   description = "Specifies the customer managed key configurations."
   type = object({
     key_vault_id                     = string,
+    key_vault_key_id                 = string,
     key_vault_key_versionless_id     = string,
     user_assigned_identity_id        = string,
     user_assigned_identity_client_id = string,
@@ -352,6 +353,7 @@ variable "customer_managed_key" {
   validation {
     condition = alltrue([
       var.customer_managed_key == null || length(split("/", try(var.customer_managed_key.key_vault_id, ""))) == 9,
+      var.customer_managed_key == null || startswith(try(var.customer_managed_key.key_vault_key_id, ""), "https://"),
       var.customer_managed_key == null || startswith(try(var.customer_managed_key.key_vault_key_versionless_id, ""), "https://"),
       var.customer_managed_key == null || length(split("/", try(var.customer_managed_key.user_assigned_identity_id, ""))) == 9,
       var.customer_managed_key == null || length(try(var.customer_managed_key.user_assigned_identity_client_id, "")) >= 2,

--- a/tests/e2e/variables.tf
+++ b/tests/e2e/variables.tf
@@ -85,6 +85,35 @@ variable "databricks_network_connectivity_config_name" {
   }
 }
 
+variable "databricks_network_policy_details" {
+  description = "Specifies the name of the ncc connectivity config name that should be attached to the databricks workspace."
+  type = object({
+    allowed_internet_destinations = optional(list(object({
+      destination               = string
+      internet_destination_type = optional(string, "DNS_NAME")
+    })), [])
+    allowed_storage_destinations = optional(list(object({
+      azure_storage_account    = string
+      storage_destination_type = string
+    })), [])
+  })
+  sensitive = false
+  nullable  = false
+  default   = {}
+  validation {
+    condition = alltrue([
+      length([for allowed_internet_destination in toset(var.databricks_network_policy_details.allowed_internet_destinations) : true if !contains(["DNS_NAME"], allowed_internet_destination.internet_destination_type)]) <= 0
+    ])
+    error_message = "Please specify a valid internet destination type for all allowed internet destionations."
+  }
+  validation {
+    condition = alltrue([
+      length([for allowed_storage_destination in toset(var.databricks_network_policy_details.allowed_storage_destinations) : true if !contains(["blob", "dfs"], allowed_storage_destination.storage_destination_type)]) <= 0
+    ])
+    error_message = "Please specify a valid storage destination type for all allowed storage destionations."
+  }
+}
+
 variable "databricks_compliance_security_profile_standards" {
   description = "Specifies which enhanced compliance security profiles ('HIPAA', 'PCI_DSS') should be enabled for the Azure Databricks workspace."
   type        = list(string)

--- a/tests/e2e/vars.tfvars
+++ b/tests/e2e/vars.tfvars
@@ -5,13 +5,27 @@ prefix      = "mydlz01"
 tags        = {}
 
 # Service
-data_platform_subscription_ids                   = []
-data_application_library_path                    = "./data-applications"
-data_application_file_variables                  = {}
-databricks_cluster_policy_library_path           = "./databricks-cluster-policies"
-databricks_cluster_policy_file_variables         = {}
-databricks_account_id                            = "515f13c1-53bb-48fb-a2c9-75e3f5d943f5"
-databricks_network_connectivity_config_name      = "ncc-northeurope-test"
+data_platform_subscription_ids              = []
+data_application_library_path               = "./data-applications"
+data_application_file_variables             = {}
+databricks_cluster_policy_library_path      = "./databricks-cluster-policies"
+databricks_cluster_policy_file_variables    = {}
+databricks_account_id                       = "515f13c1-53bb-48fb-a2c9-75e3f5d943f5"
+databricks_network_connectivity_config_name = "ncc-northeurope-test"
+databricks_network_policy_details = {
+  allowed_internet_destinations = [
+    {
+      destination               = "microsoft.com"
+      internet_destination_type = "DNS_NAME"
+    }
+  ]
+  allowed_storage_destinations = [
+    {
+      azure_storage_account    = "mbprj004intstg001"
+      storage_destination_type = "blob"
+    }
+  ]
+}
 databricks_compliance_security_profile_standards = ["PCI_DSS"]
 databricks_workspace_binding_catalog             = {}
 fabric_capacity_details = {

--- a/variables.tf
+++ b/variables.tf
@@ -342,6 +342,7 @@ variable "customer_managed_key" {
   description = "Specifies the customer managed key configurations."
   type = object({
     key_vault_id                     = string,
+    key_vault_key_id                 = string,
     key_vault_key_versionless_id     = string,
     user_assigned_identity_id        = string,
     user_assigned_identity_client_id = string,
@@ -352,6 +353,7 @@ variable "customer_managed_key" {
   validation {
     condition = alltrue([
       var.customer_managed_key == null || length(split("/", try(var.customer_managed_key.key_vault_id, ""))) == 9,
+      var.customer_managed_key == null || startswith(try(var.customer_managed_key.key_vault_key_id, ""), "https://"),
       var.customer_managed_key == null || startswith(try(var.customer_managed_key.key_vault_key_versionless_id, ""), "https://"),
       var.customer_managed_key == null || length(split("/", try(var.customer_managed_key.user_assigned_identity_id, ""))) == 9,
       var.customer_managed_key == null || length(try(var.customer_managed_key.user_assigned_identity_client_id, "")) >= 2,

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,35 @@ variable "databricks_network_connectivity_config_name" {
   }
 }
 
+variable "databricks_network_policy_details" {
+  description = "Specifies the name of the ncc connectivity config name that should be attached to the databricks workspace."
+  type = object({
+    allowed_internet_destinations = optional(list(object({
+      destination               = string
+      internet_destination_type = optional(string, "DNS_NAME")
+    })), [])
+    allowed_storage_destinations = optional(list(object({
+      azure_storage_account    = string
+      storage_destination_type = string
+    })), [])
+  })
+  sensitive = false
+  nullable  = false
+  default   = {}
+  validation {
+    condition = alltrue([
+      length([for allowed_internet_destination in toset(var.databricks_network_policy_details.allowed_internet_destinations) : true if !contains(["DNS_NAME"], allowed_internet_destination.internet_destination_type)]) <= 0
+    ])
+    error_message = "Please specify a valid internet destination type for all allowed internet destionations."
+  }
+  validation {
+    condition = alltrue([
+      length([for allowed_storage_destination in toset(var.databricks_network_policy_details.allowed_storage_destinations) : true if !contains(["blob", "dfs"], allowed_storage_destination.storage_destination_type)]) <= 0
+    ])
+    error_message = "Please specify a valid storage destination type for all allowed storage destionations."
+  }
+}
+
 variable "databricks_compliance_security_profile_standards" {
   description = "Specifies which enhanced compliance security profiles ('HIPAA', 'PCI_DSS') should be enabled for the Azure Databricks workspace."
   type        = list(string)


### PR DESCRIPTION
**Proposed changes**:
- Add support for Databricks network policy
- Update Databricks minimum provider version to `v1.81`
- Bump hashicorp/azurerm from 4.29.0 to 4.30.0
- Bump hashicorp/azuread from 3.3.0 to 3.4.0
- Restrict workspace admins
- Update cmk variable to enable cmk
